### PR TITLE
swiftLint 적용

### DIFF
--- a/iOS/SideDish/.swiftlint.yml
+++ b/iOS/SideDish/.swiftlint.yml
@@ -1,0 +1,39 @@
+disabled_rules:
+- notification_center_detachment
+- nsobject_prefer_isequal
+- void_return
+
+opt_in_rules:
+- closure_spacing
+- collection_alignment
+- closure_end_indentation
+- force_unwrapping
+- literal_expression_end_indentation
+- multiline_arguments
+- multiline_arguments_brackets
+- multiline_function_chains
+- multiline_literal_brackets
+- multiline_parameters
+- multiline_parameters_brackets
+- number_separator
+- operator_usage_whitespace
+- overridden_super_call
+- sorted_first_last
+- sorted_imports
+- toggle_bool
+- unused_import
+- vertical_parameter_alignment_on_call
+- vertical_whitespace_between_cases
+- vertical_whitespace_closing_braces
+- yoda_condition
+
+excluded:
+- Pods
+- SideDish/AppDelegate.swift
+
+identifier_name:
+    min_length:
+        error: 4
+    excluded:
+        - id
+        - URL

--- a/iOS/SideDish/.swiftlint.yml
+++ b/iOS/SideDish/.swiftlint.yml
@@ -1,7 +1,6 @@
 disabled_rules:
 - notification_center_detachment
 - nsobject_prefer_isequal
-- void_return
 - trailing_whitespace
 - closure_end_indentation
 - multiline_arguments_brackets

--- a/iOS/SideDish/.swiftlint.yml
+++ b/iOS/SideDish/.swiftlint.yml
@@ -2,6 +2,9 @@ disabled_rules:
 - notification_center_detachment
 - nsobject_prefer_isequal
 - void_return
+- trailing_whitespace
+- closure_end_indentation
+- multiline_arguments_brackets
 
 opt_in_rules:
 - closure_spacing
@@ -22,7 +25,6 @@ opt_in_rules:
 - sorted_imports
 - toggle_bool
 - unused_import
-- vertical_parameter_alignment_on_call
 - vertical_whitespace_between_cases
 - vertical_whitespace_closing_braces
 - yoda_condition
@@ -33,7 +35,10 @@ excluded:
 
 identifier_name:
     min_length:
-        error: 4
+        error: 3
     excluded:
         - id
         - URL
+        - URL
+
+line_length: 200

--- a/iOS/SideDish/Podfile
+++ b/iOS/SideDish/Podfile
@@ -6,5 +6,5 @@ target 'SideDish' do
   pod 'Toaster', :git => 'https://github.com/devxoul/Toaster.git', :branch => 'master'
   pod 'Alamofire'
   pod 'Floaty', '~> 4.2.0'
-
+  pod 'SwiftLint'
 end

--- a/iOS/SideDish/Podfile.lock
+++ b/iOS/SideDish/Podfile.lock
@@ -1,17 +1,20 @@
 PODS:
   - Alamofire (5.2.2)
   - Floaty (4.2.0)
+  - SwiftLint (0.39.2)
   - Toaster (2.3.0)
 
 DEPENDENCIES:
   - Alamofire
   - Floaty (~> 4.2.0)
+  - SwiftLint
   - Toaster (from `https://github.com/devxoul/Toaster.git`, branch `master`)
 
 SPEC REPOS:
   trunk:
     - Alamofire
     - Floaty
+    - SwiftLint
 
 EXTERNAL SOURCES:
   Toaster:
@@ -26,8 +29,9 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   Alamofire: 814429acc853c6c54ff123fc3d2ef66803823ce0
   Floaty: e2bd5a0f6f7f70899e26ff2da31081c8bee8d1b0
+  SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
   Toaster: 33d27524fb6829cdb6b247c924beab0cfa001b3e
 
-PODFILE CHECKSUM: 38ed1de5b3db8749a03163e8ad675cf4b348d16e
+PODFILE CHECKSUM: 906b761e5d299394bb5cb8259e458a1685ec980c
 
 COCOAPODS: 1.9.3

--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		A5BD9295244DCAE900D6442F /* SideDishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BD9294244DCAE900D6442F /* SideDishTests.swift */; };
 		A5BF0E2824581CBF00222FF3 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */; };
 		A5E4F581245176E1007AAA3D /* DetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E4F580245176E1007AAA3D /* DetailViewController.swift */; };
+		A5ED948F24D80932008BDFFA /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = A5ED948E24D80932008BDFFA /* .swiftlint.yml */; };
 		A5F4755E2459146000237E1E /* DishSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F4755D2459146000237E1E /* DishSection.swift */; };
 		A5F47560245917E100237E1E /* DishSectionUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F4755F245917E100237E1E /* DishSectionUseCase.swift */; };
 		A5F4756224593C0900237E1E /* StockUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F4756124593C0900237E1E /* StockUseCase.swift */; };
@@ -74,6 +75,7 @@
 		A5BD9296244DCAE900D6442F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A5BF0E2724581CBF00222FF3 /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		A5E4F580245176E1007AAA3D /* DetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailViewController.swift; sourceTree = "<group>"; };
+		A5ED948E24D80932008BDFFA /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		A5F4755D2459146000237E1E /* DishSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishSection.swift; sourceTree = "<group>"; };
 		A5F4755F245917E100237E1E /* DishSectionUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DishSectionUseCase.swift; sourceTree = "<group>"; };
 		A5F4756124593C0900237E1E /* StockUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StockUseCase.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 		A5BD9271244DCAE500D6442F = {
 			isa = PBXGroup;
 			children = (
+				A5ED948E24D80932008BDFFA /* .swiftlint.yml */,
 				A5BD927C244DCAE500D6442F /* SideDish */,
 				A5BD9293244DCAE900D6442F /* SideDishTests */,
 				A5BD927B244DCAE500D6442F /* Products */,
@@ -323,6 +326,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5ED948F24D80932008BDFFA /* .swiftlint.yml in Resources */,
 				A53BA05D244EA46A0023D27D /* BMYEONSUNG_otf.otf in Resources */,
 				A5BD928A244DCAE900D6442F /* LaunchScreen.storyboard in Resources */,
 				A5BD9287244DCAE900D6442F /* Assets.xcassets in Resources */,

--- a/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
+++ b/iOS/SideDish/SideDish.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 				A5BD9276244DCAE500D6442F /* Sources */,
 				A5BD9277244DCAE500D6442F /* Frameworks */,
 				A5BD9278244DCAE500D6442F /* Resources */,
+				A5ED949124D80BD0008BDFFA /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -365,6 +366,23 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		A5ED949124D80BD0008BDFFA /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/SwiftLint/swiftlint\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/iOS/SideDish/SideDish.xcodeproj/xcshareddata/xcschemes/SideDish.xcscheme
+++ b/iOS/SideDish/SideDish.xcodeproj/xcshareddata/xcschemes/SideDish.xcscheme
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1160"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5BD9279244DCAE500D6442F"
+               BuildableName = "SideDish.app"
+               BlueprintName = "SideDish"
+               ReferencedContainer = "container:SideDish.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A5BD928F244DCAE900D6442F"
+               BuildableName = "SideDishTests.xctest"
+               BlueprintName = "SideDishTests"
+               ReferencedContainer = "container:SideDish.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5BD9279244DCAE500D6442F"
+            BuildableName = "SideDish.app"
+            BlueprintName = "SideDish"
+            ReferencedContainer = "container:SideDish.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A5BD9279244DCAE500D6442F"
+            BuildableName = "SideDish.app"
+            BlueprintName = "SideDish"
+            ReferencedContainer = "container:SideDish.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct DetailInfoUseCase {
     
-    static func loadDetailDish(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping(DishInfo) -> ()) {
+    static func loadDetailDish(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping(DishInfo) -> Void) {
         manager.getDetailDish(id: id) {
             switch $0 {
             case .failure(let error):

--- a/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DetailInfoUseCase.swift
@@ -10,17 +10,18 @@ import Foundation
 
 struct DetailInfoUseCase {
     
-    static func loadDetailDish(with manager: NetworkManager, id: Int , failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping(DishInfo) -> ()) {
+    static func loadDetailDish(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping(DishInfo) -> ()) {
         manager.getDetailDish(id: id) {
             switch $0 {
             case .failure(let error):
                 failureHandler(error)
+                
             case .success(let data):
                 do {
                     let model = try JSONDecoder().decode(DetailDish.self, from: data)
                     completed(model.body)
                 } catch {
-                    failureHandler(.DecodeError)
+                    failureHandler(.decodeError)
                 }
             }
         }

--- a/iOS/SideDish/SideDish/Controller/DishSectionUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DishSectionUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct DishSectionUseCase {
     
-    static func loadSectionHeaders(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping([Section]) -> ()) {
+    static func loadSectionHeaders(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping([Section]) -> Void) {
         manager.getSectionHeader {
             switch $0 {
             case .failure(let error):

--- a/iOS/SideDish/SideDish/Controller/DishSectionUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/DishSectionUseCase.swift
@@ -15,12 +15,13 @@ struct DishSectionUseCase {
             switch $0 {
             case .failure(let error):
                 failureHandler(error)
+                
             case .success(let data):
                 do {
                     let model = try JSONDecoder().decode(DishSection.self, from: data)
                     completed(model.body)
                 } catch {
-                    failureHandler(.DecodeError)
+                    failureHandler(.decodeError)
                 }
             }
         }

--- a/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
@@ -10,9 +10,10 @@ import Foundation
 
 struct ImageUseCase {
     
-    static let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+    static let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
     static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
-        let imageURL = cachesDirectory.appendingPathComponent(from.lastPathComponent)
+        guard let cacheDir = cachesDirectory else { return }
+        let imageURL = cacheDir.appendingPathComponent(from.lastPathComponent)
         
         if FileManager.default.fileExists(atPath: imageURL.path) {
             handleData(from: imageURL, failureHandler: failureHandler, completed: completed)
@@ -21,6 +22,7 @@ struct ImageUseCase {
                 switch $0 {
                 case .failure(let error):
                     failureHandler(error)
+                    
                 case .success(let url):
                     handleData(from: url, failureHandler: failureHandler, completed: completed)
                     try? FileManager.default.moveItem(at: url, to: imageURL)
@@ -34,7 +36,7 @@ struct ImageUseCase {
             let data = try Data(contentsOf: url)
             completed(data)
         } catch {
-            failureHandler(.DecodeError)
+            failureHandler(.decodeError)
         }
     }
 }

--- a/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/ImageUseCase.swift
@@ -11,7 +11,7 @@ import Foundation
 struct ImageUseCase {
     
     static let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-    static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
+    static func loadImage(with manager: NetworkManager, from: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> Void, completed: @escaping(Data) -> Void) {
         guard let cacheDir = cachesDirectory else { return }
         let imageURL = cacheDir.appendingPathComponent(from.lastPathComponent)
         
@@ -31,7 +31,7 @@ struct ImageUseCase {
         }
     }
     
-    private static func handleData(from url: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> (), completed: @escaping(Data) -> ()) {
+    private static func handleData(from url: URL, failureHandler: @escaping (NetworkManager.NetworkError) -> Void, completed: @escaping(Data) -> Void) {
         do {
             let data = try Data(contentsOf: url)
             completed(data)

--- a/iOS/SideDish/SideDish/Controller/SideDishUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/SideDishUseCase.swift
@@ -10,19 +10,19 @@ import Foundation
 
 struct SideDishUseCase {
     
-    static func loadMainDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping([SideDishInfo], Int) -> ()) {
+    static func loadMainDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping([SideDishInfo], Int) -> Void) {
         manager.getMainDish {
             handleImage(result: $0, failureHandler: failureHandler, completed: completed)
         }
     }
     
-    static func loadSideDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping([SideDishInfo], Int) -> ()) {
+    static func loadSideDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping([SideDishInfo], Int) -> Void) {
         manager.getSideDish {
             handleImage(result: $0, failureHandler: failureHandler, completed: completed)
         }
     }
     
-    static func loadSoupDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping([SideDishInfo], Int) -> ()) {
+    static func loadSoupDish(with manager: NetworkManager, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping([SideDishInfo], Int) -> Void) {
         manager.getSoupDish {
             handleImage(result: $0, failureHandler: failureHandler, completed: completed)
         }
@@ -30,8 +30,8 @@ struct SideDishUseCase {
     
     static func handleImage(
         result: Result<Data, NetworkManager.NetworkError>,
-        failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in },
-        completed: @escaping([SideDishInfo], Int) -> ()
+        failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in },
+        completed: @escaping([SideDishInfo], Int) -> Void
     ) {
         switch result {
         case .failure(let error):

--- a/iOS/SideDish/SideDish/Controller/SideDishUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/SideDishUseCase.swift
@@ -28,16 +28,21 @@ struct SideDishUseCase {
         }
     }
     
-    static func handleImage (result: Result<Data, NetworkManager.NetworkError>, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping([SideDishInfo], Int) -> ()) {
-        switch result{
+    static func handleImage(
+        result: Result<Data, NetworkManager.NetworkError>,
+        failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in },
+        completed: @escaping([SideDishInfo], Int) -> ()
+    ) {
+        switch result {
         case .failure(let error):
             failureHandler(error)
+            
         case .success(let data):
             do {
                 let model = try JSONDecoder().decode(SideDish.self, from: data)
                 completed(model.sideDishes, model.menuId - 1)
             } catch {
-                failureHandler(.DecodeError)
+                failureHandler(.decodeError)
             }
         }
     }

--- a/iOS/SideDish/SideDish/Controller/StockUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/StockUseCase.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct StockUseCase {
     
-    static func isSoldOut(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping (Bool) -> ()) {
+    static func isSoldOut(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> Void = { _ in }, completed: @escaping (Bool) -> Void) {
         manager.getStock(id: id) {
             switch $0 {
             case .failure(let error):

--- a/iOS/SideDish/SideDish/Controller/StockUseCase.swift
+++ b/iOS/SideDish/SideDish/Controller/StockUseCase.swift
@@ -11,23 +11,24 @@ import Foundation
 struct StockUseCase {
     
     static func isSoldOut(with manager: NetworkManager, id: Int, failureHandler: @escaping (NetworkManager.NetworkError) -> () = { _ in }, completed: @escaping (Bool) -> ()) {
-        manager.getStock(id: id){
+        manager.getStock(id: id) {
             switch $0 {
             case .failure(let error):
                 failureHandler(error)
+                
             case .success(let data):
                 do {
-                    guard let result:[String:Int] = try JSONSerialization.jsonObject(with: data, options: []) as? [String:Int] else {
-                        failureHandler(.DecodeError)
+                    guard let result: [String: Int] = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Int] else {
+                        failureHandler(.decodeError)
                         return
                     }
                     guard let stock = result["stock"] else {
-                        failureHandler(.DecodeError)
+                        failureHandler(.decodeError)
                         return
                     }
                     completed(stock > 0)
                 } catch {
-                    failureHandler(.DecodeError)
+                    failureHandler(.decodeError)
                 }
             }
         }

--- a/iOS/SideDish/SideDish/Delegate/AppDelegate.swift
+++ b/iOS/SideDish/SideDish/Delegate/AppDelegate.swift
@@ -17,4 +17,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 }
-

--- a/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
+++ b/iOS/SideDish/SideDish/DetailView/DetailViewController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 신한섭. All rights reserved.
 //
 
-import UIKit
 import Toaster
+import UIKit
 
 class DetailViewController: UIViewController {
     
@@ -67,7 +67,9 @@ class DetailViewController: UIViewController {
     private func configureUseCase(id: Int) {
         DetailInfoUseCase.loadDetailDish(with: NetworkManager(),
                                          id: id,
-                                         failureHandler: { self.errorHandling(error: $0) }, completed: { self.model = $0 })
+                                         failureHandler: { self.errorHandling(error: $0) },
+                                         completed: { self.model = $0 }
+        )
     }
     
     private func setOriginPriceLabel(text original: String?) {
@@ -85,25 +87,25 @@ class DetailViewController: UIViewController {
     private func setupUI() {
         guard let model = model else { return }
         titleLabel.text = titleText
-        descriptionLabel.text = model.product_description
+        descriptionLabel.text = model.productDescription
         mileageLabel.text = model.point
-        deliveryFeeLabel.text = model.delivery_fee
-        deliveryInfoLabel.text = model.delivery_info
-        setOriginPriceLabel(text: model.n_price)
-        specialPriceLabel.text = model.s_price
+        deliveryFeeLabel.text = model.deliveryFee
+        deliveryInfoLabel.text = model.deliveryInfo
+        setOriginPriceLabel(text: model.originalPrice)
+        specialPriceLabel.text = model.specialPrice
         
-        for from in model.thumb_images {
+        for from in model.thumbImages {
             let imageView = UIImageView()
-            InsertImageView(into: thumbnailStackView, imageView: imageView, constraintAnchor: thumbnailScrollView)
+            insertImageView(into: thumbnailStackView, imageView: imageView, constraintAnchor: thumbnailScrollView)
             
             guard let url = URL(string: from) else {
-                errorHandling(error: .InvalidURL)
+                errorHandling(error: .invalidURL)
                 return
             }
             
             ImageUseCase.loadImage(with: NetworkManager(),
                                    from: url,
-                                   failureHandler: { self.errorHandling(error:$0) },
+                                   failureHandler: { self.errorHandling(error: $0) },
                                    completed: {
                                     let image = UIImage(data: $0)
                                     DispatchQueue.main.async {
@@ -112,18 +114,18 @@ class DetailViewController: UIViewController {
             })
         }
         
-        for from in model.detail_section {
+        for from in model.detailSection {
             let imageView = UIImageView()
-            InsertImageView(into: detailImageStackView, imageView: imageView, constraintAnchor: contentScrollView)
+            insertImageView(into: detailImageStackView, imageView: imageView, constraintAnchor: contentScrollView)
             
             guard let url = URL(string: from) else {
-                errorHandling(error: .InvalidURL)
+                errorHandling(error: .invalidURL)
                 return
             }
             
             ImageUseCase.loadImage(with: NetworkManager(),
                                    from: url,
-                                   failureHandler: { self.errorHandling(error:$0) },
+                                   failureHandler: { self.errorHandling(error: $0) },
                                    completed: {
                                     let image = UIImage(data: $0)
                                     DispatchQueue.main.async {
@@ -134,7 +136,7 @@ class DetailViewController: UIViewController {
         }
     }
     
-    private func InsertImageView(into stackView: UIStackView, imageView: UIImageView, constraintAnchor: UIScrollView) {
+    private func insertImageView(into stackView: UIStackView, imageView: UIImageView, constraintAnchor: UIScrollView) {
         imageView.contentMode = .scaleAspectFill
         stackView.addArrangedSubview(imageView)
         imageView.widthAnchor.constraint(equalTo: constraintAnchor.frameLayoutGuide.widthAnchor, multiplier: 1).isActive = true
@@ -143,8 +145,8 @@ class DetailViewController: UIViewController {
     private func alert(title: String, message: String, confirmMessage: String) {
         DispatchQueue.main.async {
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            let ok = UIAlertAction(title: confirmMessage, style: .default)
-            alert.addAction(ok)
+            let confirm = UIAlertAction(title: confirmMessage, style: .default)
+            alert.addAction(confirm)
             self.present(alert, animated: true)
         }
     }

--- a/iOS/SideDish/SideDish/LoginView/OAuthViewController.swift
+++ b/iOS/SideDish/SideDish/LoginView/OAuthViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import WebKit
 
 class OAuthViewController: UIViewController {
-
+    
     @IBOutlet weak var webView: WKWebView!
     
     override func loadView() {
@@ -26,8 +26,8 @@ class OAuthViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        let url = URL(string: "http://13.125.179.178:8080/login/github")
-        let request = URLRequest(url: url!)
+        guard let url = URL(string: "http://13.125.179.178:8080/login/github") else { return }
+        let request = URLRequest(url: url)
         webView.load(request)
     }
 }
@@ -36,33 +36,11 @@ extension OAuthViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
         decisionHandler(.allow)
         WKWebsiteDataStore.default().httpCookieStore.getAllCookies {
-            for cookie in $0 {
-                if cookie.name == "jwtToken" {
-                    NetworkManager.jwtToken = cookie.value
-                    self.dismiss(animated: true)
-                    NotificationCenter.default.post(name: .receiveCookie, object: nil)
-                }
+            for cookie in $0 where cookie.name == "jwtToken" {
+                NetworkManager.jwtToken = cookie.value
+                self.dismiss(animated: true)
+                NotificationCenter.default.post(name: .receiveCookie, object: nil)
             }
-        }
-    }
-}
-
-extension WKWebView {
-    private var httpCookieStore: WKHTTPCookieStore  { return WKWebsiteDataStore.default().httpCookieStore }
-    
-    func getCookies(for domain: String? = nil, completion: @escaping ([String : Any])->())  {
-        var cookieDict = [String : AnyObject]()
-        httpCookieStore.getAllCookies { cookies in
-            for cookie in cookies {
-                if let domain = domain {
-                    if cookie.domain.contains(domain) {
-                        cookieDict[cookie.name] = cookie.properties as AnyObject?
-                    }
-                } else {
-                    cookieDict[cookie.name] = cookie.properties as AnyObject?
-                }
-            }
-            completion(cookieDict)
         }
     }
 }

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuHeader.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuHeader.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol SectionTapped {
+protocol SectionTapped: class {
     func sectionTapped(headerView: MainMenuHeader, at section: Int, title: String)
 }
 
@@ -40,7 +40,7 @@ class MainMenuHeader: UITableViewHeaderFooterView {
     }()
     
     var index: Int!
-    var delegate: SectionTapped?
+    weak var delegate: SectionTapped?
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -49,7 +49,7 @@ class MainMenuHeader: UITableViewHeaderFooterView {
     }
     
     @objc func tapped(_ recognizer: UITapGestureRecognizer) {
-        guard let title = titleLabel.text else {return}
+        guard let title = titleLabel.text else { return }
         delegate?.sectionTapped(headerView: self, at: index, title: title)
     }
     

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuTableViewCell.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuTableViewCell.swift
@@ -18,9 +18,10 @@ class MainMenuTableViewCell: UITableViewCell {
     @IBOutlet weak var eventStackView: UIStackView!
     
     func setImageFromData(data: Data) {
+        guard let height = menuImageView?.frame.height else { return }
         DispatchQueue.main.async {
             self.menuImageView.image = UIImage(data: data)
-            self.menuImageView?.layer.cornerRadius = (self.menuImageView?.frame.height)! / 2
+            self.menuImageView?.layer.cornerRadius = height / 2
         }
     }
     

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewController.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2020 신한섭. All rights reserved.
 //
 
-import UIKit
-import Toaster
 import Floaty
+import Toaster
+import UIKit
 
 class MainMenuViewController: UIViewController {
     
     @IBOutlet weak var mainMenuTableView: UITableView!
     
-    private var mainMenuDataSource =  MainMenuViewDataSource()
+    private var mainMenuDataSource = MainMenuViewDataSource()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -49,7 +49,7 @@ class MainMenuViewController: UIViewController {
     private func setupDataSource() {
         mainMenuDataSource.handler = { cell, urlString in
             guard let requestURL = URL(string: urlString) else {
-                self.errorHandling(error: .InvalidURL)
+                self.errorHandling(error: .invalidURL)
                 return
             }
             
@@ -106,8 +106,8 @@ class MainMenuViewController: UIViewController {
     private func alertError(message: String) {
         DispatchQueue.main.async {
             let alert = UIAlertController(title: "문제가 생겼어요", message: message, preferredStyle: .alert)
-            let ok = UIAlertAction(title: "넵...", style: .default)
-            alert.addAction(ok)
+            let confirm = UIAlertAction(title: "넵...", style: .default)
+            alert.addAction(confirm)
             self.present(alert, animated: true)
         }
     }
@@ -117,7 +117,7 @@ class MainMenuViewController: UIViewController {
     }
     
     @objc func reloadSection(_ notification: Notification) {
-        guard let index = notification.userInfo?["index"] as? Int else {return}
+        guard let index = notification.userInfo?["index"] as? Int else { return }
         mainMenuTableView.reloadSections(IndexSet(index...index), with: .automatic)
     }
     

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewDataSource.swift
@@ -11,7 +11,7 @@ import UIKit
 class MainMenuViewDataSource: NSObject, UITableViewDataSource {
     
     private(set) var sideDishManager: SideDishManager
-    public var handler: (MainMenuTableViewCell, String) -> () = {_, _ in}
+    public var handler: (MainMenuTableViewCell, String) -> () = { _, _ in }
     
     override init() {
         sideDishManager = SideDishManager()
@@ -24,7 +24,7 @@ class MainMenuViewDataSource: NSObject, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier:
-            "MainMenuCell", for: indexPath) as? MainMenuTableViewCell else {return UITableViewCell()}
+            "MainMenuCell", for: indexPath) as? MainMenuTableViewCell else { return UITableViewCell() }
         let urlString = sideDishManager.sideDish(indexPath: indexPath).imageUrl
         handler(cell, urlString)
         cell.configuration(info: sideDishManager.sideDish(indexPath: indexPath))

--- a/iOS/SideDish/SideDish/MainMenuView/MainMenuViewDataSource.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/MainMenuViewDataSource.swift
@@ -11,7 +11,7 @@ import UIKit
 class MainMenuViewDataSource: NSObject, UITableViewDataSource {
     
     private(set) var sideDishManager: SideDishManager
-    public var handler: (MainMenuTableViewCell, String) -> () = { _, _ in }
+    public var handler: (MainMenuTableViewCell, String) -> Void = { _, _ in }
     
     override init() {
         sideDishManager = SideDishManager()

--- a/iOS/SideDish/SideDish/MainMenuView/PaddingLabel.swift
+++ b/iOS/SideDish/SideDish/MainMenuView/PaddingLabel.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class PaddingLabel: UILabel {
     
-    @IBInspectable var padding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 7, bottom: 0, right: 7)
+    var padding: UIEdgeInsets = UIEdgeInsets(top: 0, left: 7, bottom: 0, right: 7)
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)

--- a/iOS/SideDish/SideDish/Model/DetailDish.swift
+++ b/iOS/SideDish/SideDish/Model/DetailDish.swift
@@ -14,13 +14,26 @@ struct DetailDish: Codable {
 
 struct DishInfo: Codable {
     var id: Int
-    var top_image: String
-    var product_description: String
+    var topImage: String
+    var productDescription: String
     var point: String
-    var delivery_info: String
-    var delivery_fee: String
-    var s_price: String?
-    var n_price: String?
-    var detail_section: [String]
-    var thumb_images: [String]
+    var deliveryInfo: String
+    var deliveryFee: String
+    var specialPrice: String?
+    var originalPrice: String?
+    var detailSection: [String]
+    var thumbImages: [String]
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case topImage = "top_image"
+        case productDescription = "product_description"
+        case point
+        case deliveryInfo = "delivery_info"
+        case deliveryFee = "delivery_fee"
+        case specialPrice = "special_price"
+        case originalPrice = "n_price"
+        case detailSection = "detail_section"
+        case thumbImages = "thumb_images"
+    }
 }

--- a/iOS/SideDish/SideDish/Model/DishSection.swift
+++ b/iOS/SideDish/SideDish/Model/DishSection.swift
@@ -13,7 +13,13 @@ struct DishSection: Codable {
 }
 
 struct Section: Codable {
-    var menu_id: Int
+    var id: Int
     var title: String
     var info: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id = "menu_id"
+        case title
+        case info
+    }
 }

--- a/iOS/SideDish/SideDish/Model/NetworkManager.swift
+++ b/iOS/SideDish/SideDish/Model/NetworkManager.swift
@@ -6,15 +6,15 @@
 // Copyright © 2020 신한섭. All rights reserved.
 //
 
-import Foundation
 import Alamofire
+import Foundation
 
 protocol NetworkManageable {
-    func getResource(from: String, method: HTTPMethod, headers: HTTPHeaders?, handler : @escaping dataHandler)
+    func getResource(from: String, method: HTTPMethod, headers: HTTPHeaders?, handler : @escaping DataHandler)
 }
 
-typealias dataHandler = (Result<Data, NetworkManager.NetworkError>) -> Void
-typealias downloadHandler = (Result<URL, NetworkManager.NetworkError>) -> Void
+typealias DataHandler = (Result<Data, NetworkManager.NetworkError>) -> ()
+typealias DownloadHandler = (Result<URL, NetworkManager.NetworkError>) -> ()
 
 class NetworkManager: NetworkManageable {
     static var jwtToken: String?
@@ -30,24 +30,24 @@ class NetworkManager: NetworkManageable {
     }
     
     enum NetworkError: Error {
-        case DataEmpty
-        case DecodeError
-        case InvalidHTTPResonse
-        case InvalidStatusCode(Int)
-        case InvalidURL
+        case dataEmpty
+        case decodeError
+        case invalidHTTPResonse
+        case invalidStatusCode(Int)
+        case invalidURL
         case requestError
         
         func message() -> String {
             switch self {
-            case .DataEmpty:
+            case .dataEmpty:
                 return "데이터가 비었어요."
-            case .DecodeError:
+            case .decodeError:
                 return "응답을 복호화 하는 도중 문제가 발생했어요."
-            case .InvalidHTTPResonse:
+            case .invalidHTTPResonse:
                 return "HTTP 응답이 유효하지 않아요."
-            case .InvalidStatusCode(let code):
+            case .invalidStatusCode(let code):
                 return "HTTP 응답 \(code) 에러 발생했어요."
-            case .InvalidURL:
+            case .invalidURL:
                 return "URL이 유효하지 않아요."
             case .requestError:
                 return "요청을 보내는 중에 오류가 발생했어요."
@@ -55,7 +55,7 @@ class NetworkManager: NetworkManageable {
         }
     }
     
-    func downloadResource(from: URL, handler: @escaping downloadHandler) {
+    func downloadResource(from: URL, handler: @escaping DownloadHandler) {
         var urlRequest = URLRequest(url: from)
         urlRequest.addValue("jwtToken=" + (NetworkManager.jwtToken ?? ""), forHTTPHeaderField: "Cookie")
         URLSession.shared.downloadTask(with: urlRequest) { (url, response, error) in
@@ -65,27 +65,28 @@ class NetworkManager: NetworkManageable {
             }
             
             guard let httpResponse = response as? HTTPURLResponse else {
-                handler(.failure(.InvalidHTTPResonse))
+                handler(.failure(.invalidHTTPResonse))
                 return
             }
             
             guard httpResponse.statusCode == 200 else {
-                handler(.failure(.InvalidStatusCode(httpResponse.statusCode)))
+                handler(.failure(.invalidStatusCode(httpResponse.statusCode)))
                 return
             }
             
             guard let url = url else {
-                handler(.failure(.DataEmpty))
+                handler(.failure(.dataEmpty))
                 return
             }
             
             handler(.success(url))
-        }.resume()
+        }
+        .resume()
     }
     
-    func getResource(from: String, method: HTTPMethod, headers: HTTPHeaders?, handler: @escaping dataHandler) {
+    func getResource(from: String, method: HTTPMethod, headers: HTTPHeaders?, handler: @escaping DataHandler) {
         guard let url = URL(string: from) else {
-            handler(.failure(.InvalidURL))
+            handler(.failure(.invalidURL))
             return
         }
         
@@ -98,49 +99,50 @@ class NetworkManager: NetworkManageable {
             }
             
             guard let httpResponse = response as? HTTPURLResponse else {
-                handler(.failure(.InvalidHTTPResonse))
+                handler(.failure(.invalidHTTPResonse))
                 return
             }
             
             guard httpResponse.statusCode == 200 else {
-                handler(.failure(.InvalidStatusCode(httpResponse.statusCode)))
+                handler(.failure(.invalidStatusCode(httpResponse.statusCode)))
                 return
             }
             
             guard let data = data else {
-                handler(.failure(.DataEmpty))
+                handler(.failure(.dataEmpty))
                 return
             }
             
             handler(.success(data))
-        }.resume()
+        }
+        .resume()
     }
     
-    func getStock(id: Int, handler: @escaping dataHandler) {
+    func getStock(id: Int, handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.order + "/\(id)", method: .get, headers: nil, handler: handler)
     }
     
-    func getSectionHeader(handler: @escaping dataHandler) {
+    func getSectionHeader(handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.menuinfo, method: .get, headers: nil, handler: handler)
     }
     
-    func getMainDish(handler: @escaping dataHandler) {
+    func getMainDish(handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.main, method: .get, headers: nil, handler: handler)
     }
     
-    func getSoupDish(handler: @escaping dataHandler) {
+    func getSoupDish(handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.soup, method: .get, headers: nil, handler: handler)
     }
     
-    func getSideDish(handler: @escaping dataHandler) {
+    func getSideDish(handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.side, method: .get, headers: nil, handler: handler)
     }
     
-    func getDetailDish(id: Int, handler: @escaping dataHandler) {
+    func getDetailDish(id: Int, handler: @escaping DataHandler) {
         getResource(from: EndPoints.serverURL + EndPoints.detail + "/\(id)", method: .get, headers: nil, handler: handler)
     }
     
-    func getImageURL(from: URL, handler: @escaping downloadHandler) {
+    func getImageURL(from: URL, handler: @escaping DownloadHandler) {
         downloadResource(from: from, handler: handler)
     }
 }

--- a/iOS/SideDish/SideDish/Model/NetworkManager.swift
+++ b/iOS/SideDish/SideDish/Model/NetworkManager.swift
@@ -13,8 +13,8 @@ protocol NetworkManageable {
     func getResource(from: String, method: HTTPMethod, headers: HTTPHeaders?, handler : @escaping DataHandler)
 }
 
-typealias DataHandler = (Result<Data, NetworkManager.NetworkError>) -> ()
-typealias DownloadHandler = (Result<URL, NetworkManager.NetworkError>) -> ()
+typealias DataHandler = (Result<Data, NetworkManager.NetworkError>) -> Void
+typealias DownloadHandler = (Result<URL, NetworkManager.NetworkError>) -> Void
 
 class NetworkManager: NetworkManageable {
     static var jwtToken: String?

--- a/iOS/SideDish/SideDish/Model/SideDish.swift
+++ b/iOS/SideDish/SideDish/Model/SideDish.swift
@@ -41,5 +41,3 @@ struct Badge: Codable {
     var color: String
     var name: String
 }
-
-

--- a/iOS/SideDish/SideDish/Model/SideDishManager.swift
+++ b/iOS/SideDish/SideDish/Model/SideDishManager.swift
@@ -23,7 +23,7 @@ class SideDishManager {
         sideDish[section] = rows
         NotificationCenter.default.post(name: .ModelInserted,
                                         object: nil,
-                                        userInfo: ["index" : section])
+                                        userInfo: ["index": section])
     }
     
     func insertSection(sections: [Section]) {
@@ -32,7 +32,7 @@ class SideDishManager {
                                         object: nil)
     }
     
-    func sectionName(at index: Int) -> String{
+    func sectionName(at index: Int) -> String {
         return sections[index].title
     }
     

--- a/iOS/SideDish/SideDish/Model/UIColorExtension.swift
+++ b/iOS/SideDish/SideDish/Model/UIColorExtension.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension UIColor {
     public convenience init?(hex: String) {
-        let r, g, b: CGFloat
+        let red, greeen, blue: CGFloat
 
         if hex.hasPrefix("#") {
             let start = hex.index(hex.startIndex, offsetBy: 1)
@@ -21,11 +21,11 @@ extension UIColor {
                 var hexNumber: UInt64 = 0
 
                 if scanner.scanHexInt64(&hexNumber) {
-                    r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
-                    g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
-                    b = CGFloat((hexNumber & 0x0000ff)) / 255
+                    red = CGFloat((hexNumber & 0xff0000) >> 16) / 255
+                    greeen = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
+                    blue = CGFloat((hexNumber & 0x0000ff)) / 255
 
-                    self.init(red: r, green: g, blue: b, alpha: 1)
+                    self.init(red: red, green: greeen, blue: blue, alpha: 1)
                     return
                 }
             }
@@ -34,4 +34,3 @@ extension UIColor {
         return nil
     }
 }
-

--- a/iOS/SideDish/SideDishTests/SideDishTests.swift
+++ b/iOS/SideDish/SideDishTests/SideDishTests.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 신한섭. All rights reserved.
 //
 
-import XCTest
 @testable import SideDish
+import XCTest
 
 class SideDishTests: XCTestCase {
 
@@ -30,5 +30,4 @@ class SideDishTests: XCTestCase {
             // Put the code you want to measure the time of here.
         }
     }
-
 }


### PR DESCRIPTION
일관성 있는 코딩 스타일을 지키기 위해 lint를 적용하였음.
## default 값이 disabled인데 사용하는 rule
- notification_center_detachment
   - iOS 9.0 이상 버전부터는 system이 자동으로 observer를 제거해주기 때문에 사용하지 않아도 됨.
- nsobject_prefer_isequal
   - 비교를 하는 경우에만 equatable 프로토콜을 사용하기 위함.
- trailing_whitespace
   - 메소드와 메소드를 구분하기 위해 사이에 공백을 삽입하면 warning이 발생해서 사용 안함.
- closure_end_indentation, multiline_arguments_brackets
   - 가독성을 해친다고 생각 되어 사용 안함.
